### PR TITLE
CVF-6955: Get packer plugin into a working state

### DIFF
--- a/builder/xenserver/common/client.go
+++ b/builder/xenserver/common/client.go
@@ -624,6 +624,17 @@ func ConnectNetwork(c *Connection, networkRef xenapi.NetworkRef, vmRef xenapi.VM
 	return &vif, nil
 }
 
+func AddVMTags(c *Connection, vmRef xenapi.VMRef, tags []string) error {
+	for _, tag := range tags {
+		log.Printf("Adding tag %s to VM %s\n", tag, vmRef)
+		err := c.GetClient().VM.AddTags(c.session, vmRef, tag)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 //      Setters
 
 func (self *VM) SetIsATemplate(is_a_template bool) (err error) {

--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -223,29 +223,11 @@ func (c CommonConfig) ShouldKeepVM(state multistep.StateBag) bool {
 }
 
 func (config CommonConfig) GetSR(c *Connection) (xenapi.SRRef, error) {
-	var srRef xenapi.SRRef
 	if config.SrName == "" {
-		hostRef, err := c.GetClient().Session.GetThisHost(c.session, c.session)
-
-		if err != nil {
-			return srRef, err
-		}
-
-		pools, err := c.GetClient().Pool.GetAllRecords(c.session)
-
-		if err != nil {
-			return srRef, err
-		}
-
-		for _, pool := range pools {
-			if pool.Master == hostRef {
-				return pool.DefaultSR, nil
-			}
-		}
-
-		return srRef, errors.New(fmt.Sprintf("failed to find default SR on host '%s'", hostRef))
-
+		return getDefaultSR(c)
 	} else {
+		var srRef xenapi.SRRef
+
 		// Use the provided name label to find the SR to use
 		srs, err := c.GetClient().SR.GetByNameLabel(c.session, config.SrName)
 
@@ -267,11 +249,11 @@ func (config CommonConfig) GetSR(c *Connection) (xenapi.SRRef, error) {
 func (config CommonConfig) GetISOSR(c *Connection) (xenapi.SRRef, error) {
 	var srRef xenapi.SRRef
 	if config.SrISOName == "" {
-		return srRef, errors.New("sr_iso_name must be specified in the packer configuration")
+		return getDefaultSR(c)
 
 	} else {
 		// Use the provided name label to find the SR to use
-		srs, err := c.GetClient().SR.GetByNameLabel(c.session, config.SrName)
+		srs, err := c.GetClient().SR.GetByNameLabel(c.session, config.SrISOName)
 
 		if err != nil {
 			return srRef, err
@@ -279,11 +261,42 @@ func (config CommonConfig) GetISOSR(c *Connection) (xenapi.SRRef, error) {
 
 		switch {
 		case len(srs) == 0:
-			return srRef, fmt.Errorf("Couldn't find a SR with the specified name-label '%s'", config.SrName)
+			return srRef, fmt.Errorf("Couldn't find a SR with the specified name-label '%s'", config.SrISOName)
 		case len(srs) > 1:
-			return srRef, fmt.Errorf("Found more than one SR with the name '%s'. The name must be unique", config.SrName)
+			return srRef, fmt.Errorf("Found more than one SR with the name '%s'. The name must be unique", config.SrISOName)
 		}
 
 		return srs[0], nil
 	}
+}
+
+func getDefaultSR(c *Connection) (xenapi.SRRef, error) {
+	var srRef xenapi.SRRef
+	client := c.GetClient()
+	hostRef, err := client.Session.GetThisHost(c.session, c.session)
+
+	if err != nil {
+		return srRef, err
+	}
+
+	// The current version of the go-xen-api-client does not fully support XenAPI version 8.2
+	// In particular, some values for the pool `allowed_operations` are not recognised, resulting
+	// in a parse error when retrieving pool records. As a workaround, we only fetch pool refs.
+	pool_refs, err := client.Pool.GetAll(c.session)
+
+	if err != nil {
+		return srRef, err
+	}
+
+	for _, pool_ref := range pool_refs {
+		pool_master, err := client.Pool.GetMaster(c.session, pool_ref)
+		if err != nil {
+			return srRef, err
+		}
+		if pool_master == hostRef {
+			return client.Pool.GetDefaultSR(c.session, pool_ref)
+		}
+	}
+
+	return srRef, errors.New(fmt.Sprintf("failed to find default SR on host '%s'", hostRef))
 }

--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -24,6 +24,7 @@ type CommonConfig struct {
 	FloppyFiles        []string `mapstructure:"floppy_files"`
 	NetworkNames       []string `mapstructure:"network_names"`
 	ExportNetworkNames []string `mapstructure:"export_network_names"`
+	VMTags             []string `mapstructure:"vm_tags"`
 
 	HostPortMin uint `mapstructure:"host_port_min"`
 	HostPortMax uint `mapstructure:"host_port_max"`
@@ -131,6 +132,10 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 
 	if c.IPGetter == "" {
 		c.IPGetter = "auto"
+	}
+
+	if c.VMTags == nil {
+		c.VMTags = make([]string, 0)
 	}
 
 	// Validation

--- a/builder/xenserver/common/config.go
+++ b/builder/xenserver/common/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	DiskSize       uint              `mapstructure:"disk_size"`
 	CloneTemplate  string            `mapstructure:"clone_template"`
 	VMOtherConfig  map[string]string `mapstructure:"vm_other_config"`
+	VMTags         []string          `mapstructure:"vm_tags"`
 
 	ISOChecksum     string   `mapstructure:"iso_checksum"`
 	ISOChecksumType string   `mapstructure:"iso_checksum_type"`

--- a/builder/xenserver/common/config.hcl2spec.go
+++ b/builder/xenserver/common/config.hcl2spec.go
@@ -107,6 +107,7 @@ type FlatConfig struct {
 	PlatformArgs              map[string]string `mapstructure:"platform_args" cty:"platform_args" hcl:"platform_args"`
 	RawInstallTimeout         *string           `mapstructure:"install_timeout" cty:"install_timeout" hcl:"install_timeout"`
 	SourcePath                *string           `mapstructure:"source_path" cty:"source_path" hcl:"source_path"`
+	VMTags                    []string          `mapstructure:"vm_tags" cty:"vm_tags" hcl:"vm_tags"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -218,6 +219,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"platform_args":                &hcldec.AttrSpec{Name: "platform_args", Type: cty.Map(cty.String), Required: false},
 		"install_timeout":              &hcldec.AttrSpec{Name: "install_timeout", Type: cty.String, Required: false},
 		"source_path":                  &hcldec.AttrSpec{Name: "source_path", Type: cty.String, Required: false},
+		"vm_tags":                      &hcldec.AttrSpec{Name: "vm_tags", Type: cty.List(cty.String), Required: false},
 	}
 	return s
 }

--- a/builder/xenserver/iso/step_create_instance.go
+++ b/builder/xenserver/iso/step_create_instance.go
@@ -205,6 +205,12 @@ func (self *stepCreateInstance) Run(ctx context.Context, state multistep.StateBa
 		}
 	}
 
+	err = xscommon.AddVMTags(c, instance, config.VMTags)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to add tags: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
 	instanceId, err := c.GetClient().VM.GetUUID(c.GetSessionRef(), instance)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Unable to get VM UUID: %s", err.Error()))

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -3,7 +3,6 @@ package xva
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
@@ -43,6 +42,7 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, warns []stri
 
 	errs = packer.MultiErrorAppend(
 		errs, self.config.CommonConfig.Prepare(self.config.GetInterpContext(), &self.config.PackerConfig)...)
+	errs = packer.MultiErrorAppend(errs, self.config.SSHConfig.Prepare(self.config.GetInterpContext())...)
 
 	// Set default values
 	if self.config.VCPUsMax == 0 {
@@ -74,8 +74,12 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, warns []stri
 
 	// Validation
 
-	if self.config.SourcePath == "" {
-		errs = packer.MultiErrorAppend(errs, fmt.Errorf("A source_path must be specified"))
+	if self.config.SourcePath == "" && self.config.CloneTemplate == "" {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("Either source_path or clone_template must be specified"))
+	} else if self.config.SourcePath != "" && self.config.CloneTemplate != "" {
+		errs = packer.MultiErrorAppend(
+			errs, errors.New("Only one of source_path and clone_template must be specified"))
 	}
 
 	if len(errs.Errors) > 0 {
@@ -101,7 +105,7 @@ func (self *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (p
 	//Share state between the other steps using a statebag
 	state := new(multistep.BasicStateBag)
 	state.Put("client", c)
-	// state.Put("config", self.config)
+	state.Put("config", self.config)
 	state.Put("commonconfig", self.config.CommonConfig)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
@@ -116,8 +120,11 @@ func (self *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (p
 		},
 		&commonsteps.StepCreateFloppy{
 			Files: self.config.FloppyFiles,
+			Label: "cidata",
 		},
-		new(xscommon.StepHTTPServer),
+		&xscommon.StepHTTPServer{
+			Chan: httpReqChan,
+		},
 		&xscommon.StepUploadVdi{
 			VdiNameFunc: func() string {
 				return "Packer-floppy-disk"
@@ -134,6 +141,7 @@ func (self *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (p
 			VdiName:    self.config.ToolsIsoName,
 			VdiUuidKey: "tools_vdi_uuid",
 		},
+		new(stepCreateFromTemplate),
 		new(stepImportInstance),
 		&xscommon.StepAttachVdi{
 			VdiUuidKey: "floppy_vdi_uuid",
@@ -153,19 +161,27 @@ func (self *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (p
 			Chan:    httpReqChan,
 			Timeout: 300 * time.Minute, /*self.config.InstallTimeout*/ // @todo change this
 		},
+		&xscommon.StepForwardPortOverSSH{
+			RemotePort:  xscommon.InstanceSSHPort,
+			RemoteDest:  xscommon.InstanceSSHIP,
+			HostPortMin: self.config.HostPortMin,
+			HostPortMax: self.config.HostPortMax,
+			ResultKey:   "local_ssh_port",
+		},
 		&communicator.StepConnect{
 			Config:    &self.config.SSHConfig.Comm,
-			Host:      xscommon.CommHost,
-			SSHConfig: xscommon.SSHConfigFunc(self.config.CommonConfig.SSHConfig),
-			SSHPort:   xscommon.SSHPort,
+			Host:      xscommon.InstanceSSHIP,
+			SSHConfig: self.config.Comm.SSHConfigFunc(),
+			SSHPort:   xscommon.InstanceSSHPort,
 		},
 		new(commonsteps.StepProvision),
 		new(xscommon.StepShutdown),
-		&xscommon.StepDetachVdi{
-			VdiUuidKey: "floppy_vdi_uuid",
-		},
+		new(xscommon.StepSetVmToTemplate),
 		&xscommon.StepDetachVdi{
 			VdiUuidKey: "tools_vdi_uuid",
+		},
+		&xscommon.StepDetachVdi{
+			VdiUuidKey: "floppy_vdi_uuid",
 		},
 		new(xscommon.StepExport),
 	}

--- a/builder/xenserver/xva/step_create_from_template.go
+++ b/builder/xenserver/xva/step_create_from_template.go
@@ -1,0 +1,191 @@
+package xva
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packer"
+	xsclient "github.com/terra-farm/go-xen-api-client"
+	xscommon "github.com/xenserver/packer-builder-xenserver/builder/xenserver/common"
+)
+
+type stepCreateFromTemplate struct {
+	instance *xsclient.VMRef
+}
+
+func (self *stepCreateFromTemplate) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+
+	c := state.Get("client").(*xscommon.Connection)
+	config := state.Get("config").(xscommon.Config)
+	ui := state.Get("ui").(packer.Ui)
+
+	ui.Say("Step: Create Instance from Template")
+
+	if config.CloneTemplate == "" {
+		log.Println("Skipping creation from template - no `clone_template` configured.")
+		return multistep.ActionContinue
+	}
+
+	// Get the template to clone from
+
+	vms, err := c.GetClient().VM.GetByNameLabel(c.GetSessionRef(), config.CloneTemplate)
+
+	switch {
+	case len(vms) == 0:
+		ui.Error(fmt.Sprintf("Couldn't find a template with the name-label '%s'. Aborting.", config.CloneTemplate))
+		return multistep.ActionHalt
+	case len(vms) > 1:
+		ui.Error(fmt.Sprintf("Found more than one template with the name '%s'. The name must be unique. Aborting.", config.CloneTemplate))
+		return multistep.ActionHalt
+	}
+
+	template := vms[0]
+
+	// Clone that VM template
+	instance, err := c.GetClient().VM.Clone(c.GetSessionRef(), template, config.VMName)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error cloning VM: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+	self.instance = &instance
+
+	err = c.GetClient().VM.SetIsATemplate(c.GetSessionRef(), instance, false)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting is_a_template=false: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	err = c.GetClient().VM.SetVCPUsMax(c.GetSessionRef(), instance, int(config.VCPUsMax))
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM VCPUs Max=%d: %s", config.VCPUsMax, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	err = c.GetClient().VM.SetVCPUsAtStartup(c.GetSessionRef(), instance, int(config.VCPUsAtStartup))
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM VCPUs At Startup=%d: %s", config.VCPUsAtStartup, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	memory := int(config.VMMemory * 1024 * 1024)
+	err = c.GetClient().VM.SetMemoryLimits(c.GetSessionRef(), instance, memory, memory, memory, memory)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM memory=%d: %s", memory, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	err = c.GetClient().VM.SetPlatform(c.GetSessionRef(), instance, config.PlatformArgs)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM platform: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	err = c.GetClient().VM.SetNameDescription(c.GetSessionRef(), instance, config.VMDescription)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM description: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	// Connect Network
+
+	var network xsclient.NetworkRef
+
+	if len(config.NetworkNames) == 0 {
+		// No network has be specified. Use the management interface
+		log.Println("No network name given, attempting to use management interface")
+		pifs, err := c.GetClient().PIF.GetAll(c.GetSessionRef())
+
+		if err != nil {
+			ui.Error(fmt.Sprintf("Error getting PIFs: %s", err.Error()))
+			return multistep.ActionHalt
+		}
+
+		for _, pif := range pifs {
+			pif_rec, err := c.GetClient().PIF.GetRecord(c.GetSessionRef(), pif)
+
+			if err != nil {
+				ui.Error(fmt.Sprintf("Error getting PIF record: %s", err.Error()))
+				return multistep.ActionHalt
+			}
+
+			if pif_rec.Management {
+				network = pif_rec.Network
+			}
+
+		}
+
+		if string(network) == "" {
+			ui.Error("Error: couldn't find management network. Aborting.")
+			return multistep.ActionHalt
+		}
+
+		log.Printf("Creating VIF on network '%s' on VM '%s'\n", network, instance)
+		_, err = xscommon.ConnectNetwork(c, network, instance, "0")
+
+		if err != nil {
+			ui.Error(fmt.Sprintf("Failed to create VIF with error: %v", err))
+			return multistep.ActionHalt
+		}
+
+	} else {
+		log.Printf("Using provided network names: %v\n", config.NetworkNames)
+		// Look up each network by it's name label
+		for i, networkNameLabel := range config.NetworkNames {
+			networks, err := c.GetClient().Network.GetByNameLabel(c.GetSessionRef(), networkNameLabel)
+
+			if err != nil {
+				ui.Error(fmt.Sprintf("Error occured getting Network by name-label: %s", err.Error()))
+				return multistep.ActionHalt
+			}
+
+			switch {
+			case len(networks) == 0:
+				ui.Error(fmt.Sprintf("Couldn't find a network with the specified name-label '%s'. Aborting.", networkNameLabel))
+				return multistep.ActionHalt
+			case len(networks) > 1:
+				ui.Error(fmt.Sprintf("Found more than one network with the name '%s'. The name must be unique. Aborting.", networkNameLabel))
+				return multistep.ActionHalt
+			}
+
+			//we need the VIF index string
+			vifIndexString := fmt.Sprintf("%d", i)
+			_, err = xscommon.ConnectNetwork(c, networks[0], instance, vifIndexString)
+
+			if err != nil {
+				ui.Say(fmt.Sprintf("Failed to connect VIF with error: %v", err.Error()))
+			}
+		}
+	}
+
+	instanceId, err := c.GetClient().VM.GetUUID(c.GetSessionRef(), instance)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Unable to get VM UUID: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	state.Put("instance_uuid", instanceId)
+	ui.Say(fmt.Sprintf("Created instance '%s'", instanceId))
+
+	return multistep.ActionContinue
+}
+
+func (self *stepCreateFromTemplate) Cleanup(state multistep.StateBag) {
+	config := state.Get("config").(xscommon.Config)
+	if config.ShouldKeepVM(state) {
+		return
+	}
+
+	ui := state.Get("ui").(packer.Ui)
+	c := state.Get("client").(*xscommon.Connection)
+
+	if self.instance != nil {
+		ui.Say("Destroying VM")
+		_ = c.GetClient().VM.HardShutdown(c.GetSessionRef(), *self.instance) // redundant, just in case
+		err := c.GetClient().VM.Destroy(c.GetSessionRef(), *self.instance)
+		if err != nil {
+			ui.Error(err.Error())
+		}
+	}
+}

--- a/builder/xenserver/xva/step_create_from_template.go
+++ b/builder/xenserver/xva/step_create_from_template.go
@@ -159,6 +159,12 @@ func (self *stepCreateFromTemplate) Run(ctx context.Context, state multistep.Sta
 		}
 	}
 
+	err = xscommon.AddVMTags(c, instance, config.VMTags)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to add tags: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
 	instanceId, err := c.GetClient().VM.GetUUID(c.GetSessionRef(), instance)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Unable to get VM UUID: %s", err.Error()))

--- a/builder/xenserver/xva/step_import_instance.go
+++ b/builder/xenserver/xva/step_import_instance.go
@@ -86,6 +86,12 @@ func (self *stepImportInstance) Run(ctx context.Context, state multistep.StateBa
 		return multistep.ActionHalt
 	}
 
+	err = xscommon.AddVMTags(c, instance, config.VMTags)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Failed to add tags: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
 	ui.Say(fmt.Sprintf("Imported instance '%s'", instanceId))
 
 	return multistep.ActionContinue

--- a/builder/xenserver/xva/step_import_instance.go
+++ b/builder/xenserver/xva/step_import_instance.go
@@ -3,6 +3,7 @@ package xva
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -23,6 +24,11 @@ func (self *stepImportInstance) Run(ctx context.Context, state multistep.StateBa
 	ui := state.Get("ui").(packer.Ui)
 
 	ui.Say("Step: Import Instance")
+
+	if config.SourcePath == "" {
+		log.Println("Skipping imporing instance - no `source_path` configured.")
+		return multistep.ActionContinue
+	}
 
 	// find the SR
 	srs, err := c.GetClient().SR.GetAll(c.GetSessionRef())


### PR DESCRIPTION
- Fall back to using default SR if `sr_iso_name` is not specified
- Workaround XenAPI incompatibility in `GetDefaultSR` implementation
- Add ability for XVA builder to build from existing templates
- Update XVA builder to match ISO builder
- Allow configuring VM tags 